### PR TITLE
Allows attr 'callback' in formset-add directive.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/coverage
 test/lib
 
 .DS_Store
+.emacs*

--- a/ngDjangoFormset/controllers.js
+++ b/ngDjangoFormset/controllers.js
@@ -10,6 +10,8 @@ angular.module('ngDjangoFormset')
     self.__formsetprefix__ = $attrs.formsetPrefix || 'form';
     self.__candelete__ = $attrs.formsetCanDelete || false;
     self.__canorder__ = $attrs.formsetCanOrder || false;
+    self.__on_add__ = $attrs.onAdd || null;
+    self.__on_remove__ = $attrs.onRemove || null;
 
     self.__formset__ = null;
     self.__container__ = null;
@@ -82,7 +84,7 @@ angular.module('ngDjangoFormset')
       self.__totalforms__.val(self.__children__.length);
     }
 
-    self.addFormset = function(fn) {
+    self.addFormset = function() {
       if(self.__children__.length < self.__maxforms__) {
         self.__fid__ += 1;
         // Setup a new element from template
@@ -93,9 +95,8 @@ angular.module('ngDjangoFormset')
         self.__container__.append(element);
         // Compile after append to inherits controller
         $compile(element)(self.__formset__.scope() || {});
-        if(fn) {
-          fn.apply(null, [self]);
-        }
+	if(self.__on_add__!==null)
+	  self.callExtFunction(self.__on_add__);
         return element;
       }
     }
@@ -120,8 +121,22 @@ angular.module('ngDjangoFormset')
           } finally {
             child.remove();
           }
+	  if(self.__on_remove__!==null)
+	    self.callExtFunction(self.__on_remove__);
+
         }
         return child;
+      }
+    }
+
+    self.callExtFunction = function(fname) {
+      if(self.__formset__.scope()[fname]) {
+	if(typeof(self.__formset__.scope()[fname])=='function')
+	  self.__formset__.scope()[fname](self);
+      } else {
+	fn = window[fname];
+	if(typeof fn === 'function')
+	  fn.apply(null, [self]);
       }
     }
 

--- a/ngDjangoFormset/controllers.js
+++ b/ngDjangoFormset/controllers.js
@@ -82,7 +82,7 @@ angular.module('ngDjangoFormset')
       self.__totalforms__.val(self.__children__.length);
     }
 
-    self.addFormset = function() {
+    self.addFormset = function(fn) {
       if(self.__children__.length < self.__maxforms__) {
         self.__fid__ += 1;
         // Setup a new element from template
@@ -93,6 +93,9 @@ angular.module('ngDjangoFormset')
         self.__container__.append(element);
         // Compile after append to inherits controller
         $compile(element)(self.__formset__.scope() || {});
+        if(fn) {
+          fn.apply(null, [self]);
+        }
         return element;
       }
     }

--- a/ngDjangoFormset/directives.js
+++ b/ngDjangoFormset/directives.js
@@ -3,6 +3,7 @@ angular.module('ngDjangoFormset')
   return {
     require: 'formset',
     restrict: 'A',
+    scope: {},
     controller: 'ngDjangoFormsetCtrl',
     link: function postLink(scope, element, attrs, controller) {
       controller.setup(element);

--- a/ngDjangoFormset/directives.js
+++ b/ngDjangoFormset/directives.js
@@ -39,7 +39,12 @@ angular.module('ngDjangoFormset')
     link: function postLink(scope, element, attrs, controller) {
       element.on('click', function(event) {
         event.preventDefault();
-        controller.addFormset();
+        var fn = window[attrs.callback];
+        if(typeof fn === 'function') {
+          controller.addFormset(fn);
+        } else {
+          controller.addFormset(null);
+        } 
       });
       element.on('$destroy', function() {
         element.off('click');

--- a/ngDjangoFormset/directives.js
+++ b/ngDjangoFormset/directives.js
@@ -3,7 +3,6 @@ angular.module('ngDjangoFormset')
   return {
     require: 'formset',
     restrict: 'A',
-    scope: {},
     controller: 'ngDjangoFormsetCtrl',
     link: function postLink(scope, element, attrs, controller) {
       controller.setup(element);
@@ -39,12 +38,7 @@ angular.module('ngDjangoFormset')
     link: function postLink(scope, element, attrs, controller) {
       element.on('click', function(event) {
         event.preventDefault();
-        var fn = window[attrs.callback];
-        if(typeof fn === 'function') {
-          controller.addFormset(fn);
-        } else {
-          controller.addFormset(null);
-        } 
+        controller.addFormset();
       });
       element.on('$destroy', function() {
         element.off('click');


### PR DESCRIPTION
This commit introduces the use of an attribute named 'callback'
for the formset-add directive, so that external functions can
be called right after a new form has been added to the formset.
A potential use case might consist of calling a function to
initialize an input field as a typeahead field. Very often such
a utility comes wrapped as a Jquery plugin, reason why the
external function is called with apply and receives the
ngDjangoFormset object.
